### PR TITLE
PR: Standardize logging

### DIFF
--- a/adlfs/__init__.py
+++ b/adlfs/__init__.py
@@ -10,3 +10,9 @@ __version__ = "0.0.1"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader
+
+# Set default logging handler
+import logging
+from logging import NullHandler
+
+logging.getLogger(__name__).addHandler(NullHandler())

--- a/adlfs/cli.py
+++ b/adlfs/cli.py
@@ -362,7 +362,36 @@ class AzureDataLakeFSCommand(cmd.Cmd, object):
         return True
 
 
+def setup_logging(default_level='WARNING'):
+    """ Setup logging configuration
+
+    The logging configuration can be overridden with one environment variable:
+
+    ADLFS_LOG_LEVEL (defines logging level)
+    """
+    import logging
+    import os
+    import sys
+
+    log_level = os.environ.get('ADLFS_LOG_LEVEL', default_level)
+
+    levels = dict(
+        CRITICAL=logging.CRITICAL,
+        ERROR=logging.ERROR,
+        WARNING=logging.WARNING,
+        INFO=logging.INFO,
+        DEBUG=logging.DEBUG)
+
+    if log_level in levels:
+        log_level = levels[log_level]
+    else:
+        sys.exit("invalid ADLFS_LOG_LEVEL '{0}'".format(log_level))
+
+    logging.basicConfig(level=log_level)
+
+
 if __name__ == '__main__':
+    setup_logging()
     fs = AzureDLFileSystem()
     if len(sys.argv) > 1:
         AzureDataLakeFSCommand(fs).onecmd(' '.join(sys.argv[1:]))

--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -24,12 +24,14 @@ import time
 
 # local imports
 from .lib import DatalakeRESTInterface, auth, refresh_token
-from .utils import FileNotFoundError, PY2, ensure_writable, read_block, logger
+from .utils import FileNotFoundError, PY2, ensure_writable, read_block
 
 if sys.version_info >= (3, 4):
     import pathlib
 else:
     import pathlib2 as pathlib
+
+logger = logging.getLogger(__name__)
 
 
 class AzureDLFileSystem(object):

--- a/adlfs/lib.py
+++ b/adlfs/lib.py
@@ -15,6 +15,7 @@ and authentication code.
 
 # standard imports
 import json
+import logging
 import requests
 import requests.exceptions
 import time
@@ -24,6 +25,8 @@ import adal
 import azure
 
 client_id = "1950a258-227b-4e31-a9cf-717495945fc2"
+
+logger = logging.getLogger(__name__)
 
 
 class DatalakeRESTException(IOError):
@@ -207,7 +210,6 @@ class DatalakeRESTInterface:
         params.update(kwargs)
         func = getattr(requests, method)
         url = self.url + path
-        # logger.debug('Call: (%s, %s, %s)' % (method, url, params))
         try:
             r = func(url, params=params, headers=self.head, data=data)
         except requests.exceptions.RequestException as e:

--- a/adlfs/multithread.py
+++ b/adlfs/multithread.py
@@ -16,6 +16,7 @@ Only implements upload and download of (massive) files and directory trees.
 """
 from concurrent.futures import ThreadPoolExecutor, wait
 import glob
+import logging
 import multiprocessing
 import os
 import pickle
@@ -23,9 +24,11 @@ import time
 import uuid
 
 from .core import AzureDLPath
-from .utils import commonprefix, datadir, logger, read_block, tokenize
+from .utils import commonprefix, datadir, read_block, tokenize
 
 MAXRETRIES = 5
+
+logger = logging.getLogger(__name__)
 
 
 class ADLDownloader:

--- a/adlfs/utils.py
+++ b/adlfs/utils.py
@@ -8,7 +8,6 @@
 
 import array
 from hashlib import md5
-import logging
 import os
 import platform
 import sys
@@ -21,14 +20,6 @@ try:
 except NameError:
     class FileNotFoundError(IOError):
         pass
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s - ADLFS - %(levelname)s'
-                              ' - %(message)s')
-ch.setFormatter(formatter)
-logger.handlers = [ch]
 
 WIN = platform.platform() == 'Windows'
 


### PR DESCRIPTION
Instead of defining the logging handlers inside the library, we now defer logging to the user/application. This will make it easier to filter and redirect log messages.

I also added the ability to define the log level in the CLI, both as a convenience during development but also as an example of application-level logging.

While this doesn't fully address #47, this is a first pass.