### PR TITLE
PR: Optimize downloader

### DIFF
--- a/adlfs/cli.py
+++ b/adlfs/cli.py
@@ -179,13 +179,23 @@ class AzureDataLakeFSCommand(cmd.Cmd, object):
         parser = argparse.ArgumentParser(prog="get", add_help=False)
         parser.add_argument('remote_path', type=str)
         parser.add_argument('local_path', type=str, nargs='?', default='.')
+        parser.add_argument('-b', '--chunksize', type=int, default=2**26)
+        parser.add_argument('-c', '--threads', type=int, default=None)
         args = parser.parse_args(line.split())
 
-        ADLDownloader(self._fs, args.remote_path, args.local_path)
+        ADLDownloader(self._fs, args.remote_path, args.local_path,
+                      nthreads=args.threads, chunksize=args.chunksize)
 
     def help_get(self):
-        print("get remote-file [local-file]\n")
-        print("Retrieve the remote file and store it locally")
+        print("get [option]... remote-path [local-path]\n")
+        print("Retrieve the remote path and store it locally\n")
+        print("Options:")
+        print("    -b <int>")
+        print("    --chunksize <int>")
+        print("        Set size of chunk to retrieve atomically, in bytes.\n")
+        print("    -c <int>")
+        print("    --threads <int>")
+        print("        Set number of multiple requests to perform at a time.")
 
     def do_head(self, line):
         parser = argparse.ArgumentParser(prog="head", add_help=False)
@@ -293,13 +303,23 @@ class AzureDataLakeFSCommand(cmd.Cmd, object):
         parser = argparse.ArgumentParser(prog="put", add_help=False)
         parser.add_argument('local_path', type=str)
         parser.add_argument('remote_path', type=str, nargs='?', default='.')
+        parser.add_argument('-b', '--chunksize', type=int, default=2**26)
+        parser.add_argument('-c', '--threads', type=int, default=None)
         args = parser.parse_args(line.split())
 
-        ADLUploader(self._fs, args.remote_path, args.local_path)
+        ADLUploader(self._fs, args.remote_path, args.local_path,
+                    nthreads=args.threads, chunksize=args.chunksize)
 
     def help_put(self):
-        print("put local-file [remote-file]\n")
-        print("Store a local file on the remote machine")
+        print("put [option]... local-path [remote-path]\n")
+        print("Store a local file on the remote machine\n")
+        print("Options:")
+        print("    -b <int>")
+        print("    --chunksize <int>")
+        print("        Set size of chunk to store atomically, in bytes.\n")
+        print("    -c <int>")
+        print("    --threads <int>")
+        print("        Set number of multiple requests to perform at a time.")
 
     def do_quit(self, line):
         return True

--- a/adlfs/cli.py
+++ b/adlfs/cli.py
@@ -179,7 +179,7 @@ class AzureDataLakeFSCommand(cmd.Cmd, object):
         parser = argparse.ArgumentParser(prog="get", add_help=False)
         parser.add_argument('remote_path', type=str)
         parser.add_argument('local_path', type=str, nargs='?', default='.')
-        parser.add_argument('-b', '--chunksize', type=int, default=2**26)
+        parser.add_argument('-b', '--chunksize', type=int, default=2**22)
         parser.add_argument('-c', '--threads', type=int, default=None)
         args = parser.parse_args(line.split())
 
@@ -303,7 +303,7 @@ class AzureDataLakeFSCommand(cmd.Cmd, object):
         parser = argparse.ArgumentParser(prog="put", add_help=False)
         parser.add_argument('local_path', type=str)
         parser.add_argument('remote_path', type=str, nargs='?', default='.')
-        parser.add_argument('-b', '--chunksize', type=int, default=2**26)
+        parser.add_argument('-b', '--chunksize', type=int, default=2**22)
         parser.add_argument('-c', '--threads', type=int, default=None)
         args = parser.parse_args(line.split())
 

--- a/adlfs/cli.py
+++ b/adlfs/cli.py
@@ -44,16 +44,6 @@ class AzureDataLakeFSCommand(cmd.Cmd, object):
     def get_names(self):
         return [n for n in dir(self.__class__) if n not in self._hidden_methods]
 
-    def cmdloop(self):
-        try:
-            cmd.Cmd.cmdloop(self)
-        except KeyboardInterrupt as e:
-            print('^C')
-            self.cmdloop()
-        except:
-            print(sys.exc_info()[1])
-            self.cmdloop()
-
     def do_close(self, line):
         return True
 
@@ -424,9 +414,6 @@ if __name__ == '__main__':
     setup_logging()
     fs = AzureDLFileSystem()
     if len(sys.argv) > 1:
-        try:
-            AzureDataLakeFSCommand(fs).onecmd(' '.join(sys.argv[1:]))
-        except:
-            print(sys.exc_info()[1])
+        AzureDataLakeFSCommand(fs).onecmd(' '.join(sys.argv[1:]))
     else:
         AzureDataLakeFSCommand(fs).cmdloop()

--- a/adlfs/cli.py
+++ b/adlfs/cli.py
@@ -44,6 +44,16 @@ class AzureDataLakeFSCommand(cmd.Cmd, object):
     def get_names(self):
         return [n for n in dir(self.__class__) if n not in self._hidden_methods]
 
+    def cmdloop(self):
+        try:
+            cmd.Cmd.cmdloop(self)
+        except KeyboardInterrupt as e:
+            print('^C')
+            self.cmdloop()
+        except:
+            print(sys.exc_info()[1])
+            self.cmdloop()
+
     def do_close(self, line):
         return True
 
@@ -414,6 +424,9 @@ if __name__ == '__main__':
     setup_logging()
     fs = AzureDLFileSystem()
     if len(sys.argv) > 1:
-        AzureDataLakeFSCommand(fs).onecmd(' '.join(sys.argv[1:]))
+        try:
+            AzureDataLakeFSCommand(fs).onecmd(' '.join(sys.argv[1:]))
+        except:
+            print(sys.exc_info()[1])
     else:
         AzureDataLakeFSCommand(fs).cmdloop()

--- a/adlfs/multithread.py
+++ b/adlfs/multithread.py
@@ -51,7 +51,7 @@ class ADLDownloader:
         directory to write within. Will create directories as required.
     nthreads: int [None]
         Number of threads to use. If None, uses the number of cores.
-    chunksize: int [2**26]
+    chunksize: int [2**22]
         Number of bytes in each chunk for splitting big files. Files smaller
         than this number will always be downloaded in a single thread.
     run: bool (True)
@@ -61,7 +61,7 @@ class ADLDownloader:
     -------
     downloader object
     """
-    def __init__(self, adlfs, rpath, lpath, nthreads=None, chunksize=2**26,
+    def __init__(self, adlfs, rpath, lpath, nthreads=None, chunksize=2**22,
                  run=True):
         self.adl = adlfs
         self.rpath = rpath


### PR DESCRIPTION
I ran multiple experiments to find the optimal settings for the downloader. 

For any number of threads, a 4MB chunk size is optimal, so I updated the default:

```
Download benchmarks (10GB remote, single file local)

Threads  Chunk Size  Elapsed    Rate
-------  ----------  ---------  ------------
      4         4MB  224.3178s  45.6497 MB/s
      8        32MB  251.6219s  40.6960 MB/s
      8        16MB  237.1416s  43.1810 MB/s
      8         8MB  225.4522s  45.4198 MB/s
      8         4MB  203.5102s  50.3169 MB/s
      8         2MB  224.7242s  45.5670 MB/s
      8         1MB  354.7242s  28.8675 MB/s
     16        64MB  332.2181s  30.8231 MB/s
     16         8MB  261.7113s  39.1271 MB/s
     16         4MB  236.5254s  43.2934 MB/s
```
```
Download benchmarks (1GB remote, single file local)

Threads  Chunk Size  Elapsed    Rate
-------  ----------  ---------  ------------
     16        64MB   64.6512s  15.8388 MB/s
     16         4MB   10.7376s  95.3658 MB/s
      8        64MB   40.0978s  25.5376 MB/s
      8         4MB   13.8160s  74.1170 MB/s
```
I also updated the upload/download CLI commands, which I modified for the benchmarks.