### PR TITLE
PR: Upload/download 100GB fails without errors

### DIFF
--- a/adlfs/core.py
+++ b/adlfs/core.py
@@ -719,7 +719,7 @@ def _fetch_range(rest, path, start, end, max_attempts=10):
                              read='true')
             return resp
         except Exception as e:
-            logger.debug('Exception %e on ADL download, retrying', e,
+            logger.debug('Exception %s on ADL download, retrying', e,
                          exc_info=True)
     raise RuntimeError("Max number of ADL retries exceeded")
 

--- a/adlfs/transfer.py
+++ b/adlfs/transfer.py
@@ -193,8 +193,10 @@ class ADLTransferClient(object):
     adlfs.multithread.ADLUploader
     """
 
+    DEFAULT_TMP_PATH = os.path.join(os.path.sep, 'tmp')
+
     def __init__(self, adlfs, name, transfer, merge=None, nthreads=None,
-                 chunksize=2**28, blocksize=2**25, tmp_path='/tmp',
+                 chunksize=2**28, blocksize=2**25, tmp_path=DEFAULT_TMP_PATH,
                  tmp_unique=True, persist_path=None, delimiter=None):
         self._adlfs = adlfs
         self._name = name

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -9,7 +9,7 @@
 import pytest
 import time
 
-from tests.testing import azure
+from tests.testing import azure, posix
 from adlfs.transfer import ADLTransferClient
 
 
@@ -28,3 +28,11 @@ def test_interrupt(azure):
     client.monitor()
 
     assert client.progress[0].state != 'finished'
+
+
+def test_temporary_path(azure):
+    def transfer(adlfs, src, dst, offset, size):
+        pass
+
+    client = ADLTransferClient(azure, 'foobar', transfer=transfer, tmp_unique=False)
+    assert posix(client.temporary_path) == '/tmp'


### PR DESCRIPTION
The temporary file path still uses `/tmp` until #73 is resolved.

Fixes #71