### PR TITLE
PR: Simplify exception handling

### DIFF
--- a/adlfs/multithread.py
+++ b/adlfs/multithread.py
@@ -319,4 +319,11 @@ def put_chunk(adlfs, src, dst, offset, size, blocksize, delimiter=None,
 
 
 def merge_chunks(adlfs, outfile, files, shutdown_event=None):
-    return adlfs.concat(outfile, files)
+    try:
+        adlfs.concat(outfile, files)
+    except Exception as e:
+        exception = repr(e)
+        logger.debug('Merged failed %s; %s', outfile, exception)
+        return exception
+    logger.debug('Merged %s', outfile)
+    return None

--- a/adlfs/transfer.py
+++ b/adlfs/transfer.py
@@ -331,13 +331,6 @@ class ADLTransferClient(object):
                 chunks=chunks))
         return files
 
-    def _status(self, src, dst):
-        dic = self._files[(src, dst)]
-        elapsed = dic['stop'] - dic['start']
-        rate = dic['length'] / elapsed / 1024 / 1024
-        logger.info("Transferred %s -> %s in %f seconds at %f MB/s",
-                    src, dst, elapsed, rate)
-
     def _update(self, future):
         if future in self._cfutures:
             obj = self._cfutures[future]
@@ -373,7 +366,7 @@ class ADLTransferClient(object):
                 else:
                     self._fstates[parent] = 'finished'
                     self._files[parent]['stop'] = time.time()
-                    self._status(src, dst)
+                    logger.info("Transferred %s -> %s", src, dst)
             elif cstates.contains_none('running'):
                 logger.debug("Transfer failed: %s", cstates)
                 self._fstates[parent] = 'errored'
@@ -388,7 +381,7 @@ class ADLTransferClient(object):
                 result = future.result()
                 self._fstates[(src, dst)] = 'finished'
                 self._files[(src, dst)]['stop'] = time.time()
-                self._status(src, dst)
+                logger.info("Transferred %s -> %s", src, dst)
         self.save()
 
     def run(self, nthreads=None, monitor=True, before_start=None):

--- a/adlfs/transfer.py
+++ b/adlfs/transfer.py
@@ -102,7 +102,7 @@ class StateManager(object):
 
 
 # Named tuples used to serialize client progress
-File = namedtuple('File', 'src dst state length start stop chunks')
+File = namedtuple('File', 'src dst state length start stop chunks exception')
 Chunk = namedtuple('Chunk', 'name state offset retries expected actual exception')
 
 
@@ -196,7 +196,7 @@ class ADLTransferClient(object):
         Using a tuple of the file source/destination as the key, this
         dictionary stores the file metadata and all chunk states. The
         dictionary key is `(src, dst)` and the value is
-        `dict(length, start, stop, cstates)`.
+        `dict(length, start, stop, cstates, exception)`.
     self._chunks: dict
         Using a tuple of the chunk name/offset as the key, this dictionary
         stores the chunk metadata and has a reference to the chunk's parent
@@ -284,7 +284,8 @@ class ADLTransferClient(object):
             length=length,
             start=None,
             stop=None,
-            cstates=cstates)
+            cstates=cstates,
+            exception=None)
 
     def _submit(self, fn, *args, **kwargs):
         kwargs['shutdown_event'] = self._shutdown_event
@@ -328,7 +329,8 @@ class ADLTransferClient(object):
                 length=self._files[key]['length'],
                 start=self._files[key]['start'],
                 stop=self._files[key]['stop'],
-                chunks=chunks))
+                chunks=chunks,
+                exception=self._files[key]['exception']))
         return files
 
     def _update(self, future):
@@ -340,6 +342,7 @@ class ADLTransferClient(object):
             if future.cancelled():
                 cstates[obj] = 'cancelled'
             elif future.exception():
+                self._chunks[obj]['exception'] = repr(future.exception())
                 cstates[obj] = 'errored'
             else:
                 nbytes, exception = future.result()
@@ -376,12 +379,17 @@ class ADLTransferClient(object):
             if future.cancelled():
                 self._fstates[(src, dst)] = 'cancelled'
             elif future.exception():
+                self._files[(src, dst)]['exception'] = repr(future.exception())
                 self._fstates[(src, dst)] = 'errored'
             else:
-                result = future.result()
-                self._fstates[(src, dst)] = 'finished'
-                self._files[(src, dst)]['stop'] = time.time()
-                logger.info("Transferred %s -> %s", src, dst)
+                exception = future.result()
+                self._files[(src, dst)]['exception'] = exception
+                if exception:
+                    self._fstates[(src, dst)] = 'errored'
+                else:
+                    self._fstates[(src, dst)] = 'finished'
+                    self._files[(src, dst)]['stop'] = time.time()
+                    logger.info("Transferred %s -> %s", src, dst)
         self.save()
 
     def run(self, nthreads=None, monitor=True, before_start=None):

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -83,13 +83,19 @@ def verify(adl, progress, lfile, rfile):
         for chunk in f.chunks:
             if chunk.state == 'finished':
                 chunks_finished += 1
-            else:
+            elif chunk.exception:
                 print("[{}] file {} -> {}, chunk {} {}: {}".format(
                     chunk.state, f.src, f.dst, chunk.name, chunk.offset,
                     chunk.exception))
-        print("[{:4d}/{:4d} chunks] {} -> {}".format(chunks_finished,
-                                                     len(f.chunks),
-                                                     f.src, f.dst))
+            else:
+                print("[{}] file {} -> {}, chunk {} {}".format(
+                    chunk.state, f.src, f.dst, chunk.name, chunk.offset))
+        if f.exception:
+            print("[{:4d}/{:4d} chunks] {} -> {}: {}".format(
+                chunks_finished, len(f.chunks), f.src, f.dst, f.exception))
+        else:
+            print("[{:4d}/{:4d} chunks] {} -> {}".format(
+                chunks_finished, len(f.chunks), f.src, f.dst))
 
 
 @benchmark

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import shutil
 import sys
 import time
 
@@ -154,16 +155,17 @@ if __name__ == '__main__':
 
     # Required setup until outstanding issues are resolved
     adl.mkdir(remoteFolderName)
-    if adl.exists(remoteFolderName + '/50gbfile.txt'):
-        adl.rm(remoteFolderName + '/50gbfile.txt')
-    if adl.exists(remoteFolderName + '/50_1GB_Files'):
-        adl.rm(remoteFolderName + '/50_1GB_Files', recursive=True)
 
     # Upload/download 1 50GB files
 
     lpath_up = os.path.join(localdir, '50gbfile.txt')
     lpath_down = os.path.join(localdir, '50gbfile.txt.out')
     rpath = remoteFolderName + '/50gbfile.txt'
+
+    if adl.exists(rpath):
+        adl.rm(rpath)
+    if os.path.exists(lpath_down):
+        os.remove(lpath_down)
 
     bench_upload_1_50gb(adl, lpath_up, rpath, nthreads)
     bench_download_1_50gb(adl, lpath_down, rpath, nthreads)
@@ -175,6 +177,11 @@ if __name__ == '__main__':
     lpath_up = os.path.join(localdir, '50_1GB_Files')
     lpath_down = os.path.join(localdir, '50_1GB_Files.out')
     rpath = remoteFolderName + '/50_1GB_Files'
+
+    if adl.exists(rpath):
+        adl.rm(rpath, recursive=True)
+    if os.path.exists(lpath_down):
+        shutil.rmtree(lpath_down)
 
     bench_upload_50_1gb(adl, lpath_up, rpath, nthreads)
     bench_download_50_1gb(adl, lpath_down, rpath, nthreads)


### PR DESCRIPTION
As retry logic is handled in `adlfs.core`, we no longer need the explicit retry logic in the threads.

I added exception handling when transferring chunks or merging. I also improved resistance to errors when benchmarking. This will help with debugging.