### PR TITLE
Optimize the merge call to remove the temp dir

### DIFF
--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -450,7 +450,7 @@ def merge_chunks(adlfs, outfile, files, shutdown_event=None):
     try:
         # note that it is assumed that only temp files from this run are in the segment folder created.
         # so this call is optimized to instantly delete the temp folder on concat.
-        adlfs.concat(outfile, files, True)
+        adlfs.concat(outfile, files, delete_source=True)
     except Exception as e:
         exception = repr(e)
         logger.debug('Merged failed %s; %s', outfile, exception)

--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -448,7 +448,9 @@ def put_chunk(adlfs, src, dst, offset, size, buffersize, blocksize, delimiter=No
 
 def merge_chunks(adlfs, outfile, files, shutdown_event=None):
     try:
-        adlfs.concat(outfile, files)
+        # note that it is assumed that only temp files from this run are in the segment folder created.
+        # so this call is optimized to instantly delete the temp folder on concat.
+        adlfs.concat(outfile, files, True)
     except Exception as e:
         exception = repr(e)
         logger.debug('Merged failed %s; %s', outfile, exception)


### PR DESCRIPTION
This results in the concat operation taking substantially less time.