### PR TITLE
PR: Actionable errors

### DIFF
--- a/azure/datalake/store/cli.py
+++ b/azure/datalake/store/cli.py
@@ -25,7 +25,6 @@ import stat
 import sys
 
 from azure.datalake.store.core import AzureDLFileSystem
-from azure.datalake.store.lib import auth
 from azure.datalake.store.multithread import ADLDownloader, ADLUploader
 from azure.datalake.store.utils import write_stdout
 

--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -17,15 +17,12 @@ which is compatible with the built-in File.
 # standard imports
 import io
 import logging
-import os
-import re
 import sys
-import time
 
 # local imports
 from .exceptions import FileNotFoundError, PermissionError
-from .lib import DatalakeRESTInterface, auth, refresh_token
-from .utils import PY2, ensure_writable, read_block
+from .lib import DatalakeRESTInterface
+from .utils import ensure_writable, read_block
 
 if sys.version_info >= (3, 4):
     import pathlib

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -238,14 +238,15 @@ class DatalakeRESTInterface:
         logger.debug(msg)
 
     def log_response_and_raise(self, response, exception):
-        msg = "Exception {}\n{}\n{}".format(
-            repr(exception),
-            response.status_code,
-            "\n".join(["{}: {}".format(header, response.headers[header])
-                       for header in response.headers]))
-        msg += "\n\n{}".format(response.content[:MAX_CONTENT_LENGTH])
-        if int(response.headers['content-length']) > MAX_CONTENT_LENGTH:
-            msg += "\n(Response body was truncated)"
+        msg = "Exception " + repr(exception)
+        if response is not None:
+            msg += "\n{}\n{}".format(
+                response.status_code,
+                "\n".join(["{}: {}".format(header, response.headers[header])
+                        for header in response.headers]))
+            msg += "\n\n{}".format(response.content[:MAX_CONTENT_LENGTH])
+            if int(response.headers['content-length']) > MAX_CONTENT_LENGTH:
+                msg += "\n(Response body was truncated)"
         logger.error(msg)
         raise exception
 

--- a/azure/datalake/store/transfer.py
+++ b/azure/datalake/store/transfer.py
@@ -15,8 +15,6 @@ from collections import namedtuple, Counter
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import multiprocessing
-import os
-import pickle
 import signal
 import sys
 import threading

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -26,8 +26,7 @@ def benchmark(f):
 
 
 def mock_client(adl, nthreads):
-    def transfer(adlfs, src, dst, offset, size, blocksize, retries=5,
-                 shutdown_event=None):
+    def transfer(adlfs, src, dst, offset, size, buffersize, blocksize, shutdown_event=None):
         pass
 
     def merge(adlfs, outfile, files, shutdown_event=None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,8 @@
 import io
 import sys
 
+import pytest
+
 from tests.testing import azure, azure_teardown, my_vcr, posix, tmpfile, working_dir
 
 test_dir = working_dir()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,8 +9,6 @@
 import io
 import sys
 
-import pytest
-
 from tests.testing import azure, azure_teardown, my_vcr, posix, tmpfile, working_dir
 
 test_dir = working_dir()

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -33,7 +33,7 @@ def test_shutdown(azure):
 
 
 def test_submit_and_run(azure):
-    def transfer(adlfs, src, dst, offset, size, blocksize, buffersize, retries=5, shutdown_event=None):
+    def transfer(adlfs, src, dst, offset, size, blocksize, buffersize, shutdown_event=None):
         time.sleep(0.1)
         return size, None
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -7,7 +7,6 @@
 # --------------------------------------------------------------------------
 
 import os
-import pytest
 import time
 
 from azure.datalake.store.core import AzureDLPath


### PR DESCRIPTION
When debugging, the request and response is grouped respectively into a single message for clearer logs. We also now record Azure operation and parameters.

When an exception occurs, we record the response and body along with the exception. This will happen with all HTTP status codes in the 4xx or 5xx range.

I also removed unused imports and file/chunk metadata.

Fixes #91.