### PR TITLE
Fix headers to ensure unique IDs

### DIFF
--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -279,9 +279,10 @@ class DatalakeRESTInterface:
         func = getattr(requests, method)
         url = self.url + path
         try:
-            self.head['x-ms-client-request-id'] = str(uuid.uuid1())
-            self._log_request(method, url, op, path, kwargs, self.head)
-            r = func(url, params=params, headers=self.head, data=data, stream=stream)
+            headers = self.head
+            headers['x-ms-client-request-id'] = str(uuid.uuid1())
+            self._log_request(method, url, op, path, kwargs, headers)
+            r = func(url, params=params, headers=headers, data=data, stream=stream)
         except requests.exceptions.RequestException as e:
             raise DatalakeRESTException('HTTP error: %s', str(e))
 


### PR DESCRIPTION
by modifying the global self.head property within the Call function, there is no guarantee that it is not modified again by a different thread before the current thread finishes logging and execution. assigning to a local variable and using that should alleviate this issue.