### PR TITLE
PR: Add specific exception for bad offset errors

### DIFF
--- a/azure/datalake/store/exceptions.py
+++ b/azure/datalake/store/exceptions.py
@@ -23,3 +23,9 @@ try:
 except NameError:
     class PermissionError(OSError):
         pass
+
+class DatalakeBadOffsetException(IOError):
+    pass
+
+class DatalakeRESTException(IOError):
+    pass

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -26,13 +26,11 @@ import uuid
 import adal
 import azure
 
+from .exceptions import DatalakeBadOffsetException, DatalakeRESTException
 from .exceptions import FileNotFoundError, PermissionError
 
 logger = logging.getLogger(__name__)
 
-
-class DatalakeRESTException(IOError):
-    pass
 
 default_tenant = os.environ.get('azure_tenant_id', "common")
 default_username = os.environ.get('azure_username', None)
@@ -248,6 +246,11 @@ class DatalakeRESTInterface:
         logger.error(msg)
         raise exception
 
+    def _is_json_response(self, response):
+        if not 'content-type' in response.headers:
+            return False
+        return response.headers['content-type'].startswith('application/json')
+
     def call(self, op, path='', **kwargs):
         """ Execute a REST call
 
@@ -292,18 +295,24 @@ class DatalakeRESTInterface:
             self.log_response_and_raise(r, FileNotFoundError(path))
         elif r.status_code >= 400:
             err = DatalakeRESTException("Data-lake REST exception: %s", op)
+            if self._is_json_response(r):
+                out = r.json()
+                if 'RemoteException' in out:
+                    exception = out['RemoteException']['exception']
+                    message = out['RemoteException']['message']
+                    if exception == 'BadOffsetException':
+                        err = DatalakeBadOffsetException(message)
             self.log_response_and_raise(r, err)
         else:
             self._log_response(r)
 
-        if 'content-type' in r.headers:
-            if r.headers['content-type'].startswith('application/json'):
-                out = r.json()
-                if out.get('boolean', True) is False:
-                    err = DatalakeRESTException('Operation failed: %s, %s',
-                                                op, path)
-                    self.log_response_and_raise(r, err)
-                return out
+        if self._is_json_response(r):
+            out = r.json()
+            if out.get('boolean', True) is False:
+                err = DatalakeRESTException('Operation failed: %s, %s',
+                                            op, path)
+                self.log_response_and_raise(r, err)
+            return out
         return r
 
 """

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -9,9 +9,9 @@
 import pytest
 import time
 
+from azure.datalake.store.exceptions import DatalakeRESTException
 from azure.datalake.store.lib import (
-    refresh_token, DatalakeRESTInterface, DatalakeRESTException,
-    ManagementRESTInterface)
+    refresh_token, DatalakeRESTInterface, ManagementRESTInterface)
 
 from tests import settings
 from tests.testing import my_vcr


### PR DESCRIPTION
I moved the catch-all DatalakeRESTException with the other exceptions.

I also specifically handle bad offset exceptions at the lowest level so it can handled as needed higher up.

Needed for #85.