### PR TITLE
PR: Miscellaneous fixes

### DIFF
--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -617,69 +617,73 @@ class AzureDLFile(object):
         If force=True, flushes all data in the buffer, even if it doesn't end
         with a delimiter; appropriate when closing the file.
         """
-        if self.mode in {'wb', 'ab'} and not self.closed:
-            if self.buffer.tell() == 0:
-                if force and self.first_write:
+        if not self.writable() and self.closed:
+            return
+
+        if self.buffer.tell() == 0:
+            if force and self.first_write:
+                _put_data(self.azure.azure,
+                          'CREATE',
+                          path=self.path.as_posix(),
+                          data=None,
+                          overwrite='true',
+                          write='true')
+                self.first_write = False
+            return
+
+        self.buffer.seek(0)
+        data = self.buffer.read()
+
+        if self.delimiter:
+            while len(data) >= self.blocksize:
+                place = data[:self.blocksize].rfind(self.delimiter)
+                if place < 0:
+                    # not found - write whole block
+                    limit = self.blocksize
+                else:
+                    limit = place + len(self.delimiter)
+                if self.first_write:
                     _put_data(self.azure.azure,
                               'CREATE',
                               path=self.path.as_posix(),
-                              data=None,
+                              data=data[:limit],
                               overwrite='true',
                               write='true')
                     self.first_write = False
-                return
-            self.buffer.seek(0)
-            data = self.buffer.read()
-            if self.delimiter:
-                while len(data) >= self.blocksize:
-                    place = data[:self.blocksize].rfind(self.delimiter)
-                    if place < 0:
-                        # not found - write whole block
-                        limit = self.blocksize
-                    else:
-                        limit = place + len(self.delimiter)
-                    if self.first_write:
-                        out = _put_data(self.azure.azure,
-                                        'CREATE',
-                                        path=self.path.as_posix(),
-                                        data=data[:limit],
-                                        overwrite='true',
-                                        write='true')
-                        self.first_write = False
-                    else:
-                        out = _put_data(self.azure.azure,
-                                        'APPEND',
-                                        path=self.path.as_posix(),
-                                        data=data[:limit],
-                                        append='true')
-                    logger.debug('Wrote %d bytes to %s' % (limit, self))
-                    data = data[limit:]
-                self.buffer = io.BytesIO(data)
-                self.buffer.seek(0, 2)
-            if not self.delimiter or force:
-                zero_offset = self.tell() - len(data)
-                offsets = range(0, len(data), self.blocksize)
-                for o in offsets:
-                    offset = zero_offset + o
-                    d2 = data[o:o+self.blocksize]
-                    if self.first_write:
-                        out = _put_data(self.azure.azure,
-                                        'CREATE',
-                                        path=self.path.as_posix(),
-                                        data=d2,
-                                        overwrite='true',
-                                        write='true')
-                        self.first_write = False
-                    else:
-                        out = _put_data(self.azure.azure,
-                                        'APPEND',
-                                        path=self.path.as_posix(),
-                                        data=d2,
-                                        offset=offset,
-                                        append='true')
-                    logger.debug('Wrote %d bytes to %s' % (len(d2), self))
-                self.buffer = io.BytesIO()
-            return out
+                else:
+                    _put_data(self.azure.azure,
+                              'APPEND',
+                              path=self.path.as_posix(),
+                              data=data[:limit],
+                              append='true')
+                logger.debug('Wrote %d bytes to %s' % (limit, self))
+                data = data[limit:]
+            self.buffer = io.BytesIO(data)
+            self.buffer.seek(0, 2)
+
+        if not self.delimiter or force:
+            zero_offset = self.tell() - len(data)
+            offsets = range(0, len(data), self.blocksize)
+            for o in offsets:
+                offset = zero_offset + o
+                d2 = data[o:o+self.blocksize]
+                if self.first_write:
+                    _put_data(self.azure.azure,
+                              'CREATE',
+                              path=self.path.as_posix(),
+                              data=d2,
+                              overwrite='true',
+                              write='true')
+                    self.first_write = False
+                else:
+                    _put_data(self.azure.azure,
+                              'APPEND',
+                              path=self.path.as_posix(),
+                              data=d2,
+                              offset=offset,
+                              append='true')
+                logger.debug('Wrote %d bytes to %s' % (len(d2), self))
+            self.buffer = io.BytesIO()
 
     def close(self):
         """ Close file
@@ -688,7 +692,7 @@ class AzureDLFile(object):
         """
         if self.closed:
             return
-        if self.mode in {'wb', 'ab'}:
+        if self.writable():
             self.flush(force=True)
             self.azure.invalidate_cache(self.path.as_posix())
         self.closed = True

--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -617,7 +617,7 @@ class AzureDLFile(object):
         If force=True, flushes all data in the buffer, even if it doesn't end
         with a delimiter; appropriate when closing the file.
         """
-        if not self.writable() and self.closed:
+        if not self.writable() or self.closed:
             return
 
         if self.buffer.tell() == 0:

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -222,6 +222,11 @@ class DatalakeRESTInterface:
                           for header in headers])
         logger.debug(msg)
 
+    def _content_truncated(self, response):
+        if 'content-length' not in response.headers:
+            return False
+        return int(response.headers['content-length']) > MAX_CONTENT_LENGTH
+
     def _log_response(self, response, payload=False):
         msg = "HTTP Response\n{}\n{}".format(
             response.status_code,
@@ -229,7 +234,7 @@ class DatalakeRESTInterface:
                        for header in response.headers]))
         if payload:
             msg += "\n\n{}".format(response.content[:MAX_CONTENT_LENGTH])
-            if int(response.headers['content-length']) > MAX_CONTENT_LENGTH:
+            if self._content_truncated(response):
                 msg += "\n(Response body was truncated)"
         logger.debug(msg)
 
@@ -241,7 +246,7 @@ class DatalakeRESTInterface:
                 "\n".join(["{}: {}".format(header, response.headers[header])
                         for header in response.headers]))
             msg += "\n\n{}".format(response.content[:MAX_CONTENT_LENGTH])
-            if int(response.headers['content-length']) > MAX_CONTENT_LENGTH:
+            if self._content_truncated(response):
                 msg += "\n(Response body was truncated)"
         logger.error(msg)
         raise exception

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -238,7 +238,7 @@ class DatalakeRESTInterface:
                 msg += "\n(Response body was truncated)"
         logger.debug(msg)
 
-    def log_response_and_raise(self, response, exception):
+    def log_response_and_raise(self, response, exception, level=logging.ERROR):
         msg = "Exception " + repr(exception)
         if response is not None:
             msg += "\n{}\n{}".format(
@@ -248,7 +248,7 @@ class DatalakeRESTInterface:
             msg += "\n\n{}".format(response.content[:MAX_CONTENT_LENGTH])
             if self._content_truncated(response):
                 msg += "\n(Response body was truncated)"
-        logger.error(msg)
+        logger.log(level, msg)
         raise exception
 
     def _is_json_response(self, response):
@@ -307,6 +307,7 @@ class DatalakeRESTInterface:
                     exception = out['RemoteException']['exception']
                     if exception == 'BadOffsetException':
                         err = DatalakeBadOffsetException(path)
+                        self.log_response_and_raise(r, err, level=logging.DEBUG)
             self.log_response_and_raise(r, err)
         else:
             self._log_response(r)

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -282,7 +282,7 @@ class DatalakeRESTInterface:
         func = getattr(requests, method)
         url = self.url + path
         try:
-            headers = self.head
+            headers = self.head.copy()
             headers['x-ms-client-request-id'] = str(uuid.uuid1())
             self._log_request(method, url, op, path, kwargs, headers)
             r = func(url, params=params, headers=headers, data=data, stream=stream)

--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -239,7 +239,7 @@ def get_chunk(adlfs, src, dst, offset, size, buffersize, blocksize, shutdown_eve
                     nbytes += nwritten
     except Exception as e:
         exception = repr(e)
-        logger.debug('Download failed %s; %s', dst, exception)
+        logger.error('Download failed %s; %s', dst, exception)
         return nbytes, exception
     logger.debug('Downloaded to %s, byte offset %s', dst, offset)
     return nbytes, None
@@ -436,7 +436,7 @@ def put_chunk(adlfs, src, dst, offset, size, buffersize, blocksize, delimiter=No
                         nbytes += nwritten
     except Exception as e:
         exception = repr(e)
-        logger.debug('Upload failed %s; %s', src, exception)
+        logger.error('Upload failed %s; %s', src, exception)
         return nbytes, exception
     logger.debug('Uploaded from %s, byte offset %s', src, offset)
     return nbytes, None
@@ -449,7 +449,7 @@ def merge_chunks(adlfs, outfile, files, shutdown_event=None):
         adlfs.concat(outfile, files, delete_source=True)
     except Exception as e:
         exception = repr(e)
-        logger.debug('Merged failed %s; %s', outfile, exception)
+        logger.error('Merged failed %s; %s', outfile, exception)
         return exception
     logger.debug('Merged %s', outfile)
     return None

--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -234,9 +234,10 @@ def get_chunk(adlfs, src, dst, offset, size, buffersize, blocksize, shutdown_eve
             for chunk in response.iter_content(chunk_size=blocksize):
                 if shutdown_event and shutdown_event.is_set():
                     return nbytes, None
-                nwritten = fout.write(chunk)
-                if nwritten:
-                    nbytes += nwritten
+                if chunk:
+                    nwritten = fout.write(chunk)
+                    if nwritten:
+                        nbytes += nwritten
     except Exception as e:
         exception = repr(e)
         logger.error('Download failed %s; %s', dst, exception)


### PR DESCRIPTION
When testing bad offset errors, I find a few minor issues:

- explicitly copy headers dictionary (by default Python copies reference)
- clean up exception messages (formatted messages had raw `%s` in string)
- removed one level of indentation from `flush()`
- use `writable()` check instead of comparing against hard-coded set of file modes