### PR TITLE
PR: Fix silent errors

### DIFF
--- a/azure/datalake/store/exceptions.py
+++ b/azure/datalake/store/exceptions.py
@@ -29,5 +29,9 @@ class DatalakeBadOffsetException(IOError):
     pass
 
 
+class DatalakeIncompleteTransferException(IOError):
+    pass
+
+
 class DatalakeRESTException(IOError):
     pass

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -209,10 +209,11 @@ class DatalakeRESTInterface:
         self.token = token
         self.head = {'Authorization': 'Bearer ' + token['access']}
         self.url = 'https://%s.%s/webhdfs/v1/' % (store_name, url_suffix)
-        self.user_agent = "python/{} ({}) {}/{} Azure-Data-Lake-Store-SDK-For-Python".format(platform.python_version(), 
-                                                       platform.platform(),
-                                                       __name__,
-                                                       __version__)
+        self.user_agent = "python/{} ({}) {}/{} Azure-Data-Lake-Store-SDK-For-Python".format(
+            platform.python_version(),
+            platform.platform(),
+            __name__,
+            __version__)
 
     def _check_token(self):
         if time.time() - self.token['time'] > self.token['expiresIn'] - 100:
@@ -249,8 +250,9 @@ class DatalakeRESTInterface:
         if response is not None:
             msg += "\n{}\n{}".format(
                 response.status_code,
-                "\n".join(["{}: {}".format(header, response.headers[header])
-                        for header in response.headers]))
+                "\n".join([
+                    "{}: {}".format(header, response.headers[header])
+                    for header in response.headers]))
             msg += "\n\n{}".format(response.content[:MAX_CONTENT_LENGTH])
             if self._content_truncated(response):
                 msg += "\n(Response body was truncated)"

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -25,7 +25,6 @@ import platform
 
 # 3rd party imports
 import adal
-import azure
 
 from .exceptions import DatalakeBadOffsetException, DatalakeRESTException
 from .exceptions import FileNotFoundError, PermissionError

--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -216,6 +216,18 @@ class ADLDownloader(object):
 
         self.client.run(nthreads, monitor, before_start=touch)
 
+    def active(self):
+        """ Return whether the downloader is active """
+        return self.client.active
+
+    def successful(self):
+        """
+        Return whether the downloader completed successfully.
+
+        It will raise AssertionError if the downloader is active.
+        """
+        return self.client.successful
+
     def __str__(self):
         return "<ADL Download: %s -> %s (%s)>" % (self.rpath, self.lpath,
                                                   self.client.status)
@@ -419,6 +431,18 @@ class ADLUploader(object):
             To watch and wait (block) until completion.
         """
         self.client.run(nthreads, monitor)
+
+    def active(self):
+        """ Return whether the uploader is active """
+        return self.client.active
+
+    def successful(self):
+        """
+        Return whether the uploader completed successfully.
+
+        It will raise AssertionError if the uploader is active.
+        """
+        return self.client.successful
 
     def __str__(self):
         return "<ADL Upload: %s -> %s (%s)>" % (self.lpath, self.rpath,

--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -394,8 +394,8 @@ class ADLUploader(object):
             rfiles = [self.rpath / AzureDLPath(f).relative_to(prefix)
                       for f in lfiles]
         elif lfiles:
-            if (self.client._adlfs.exists(self.rpath) and
-                        self.client._adlfs.info(self.rpath)['type'] == "DIRECTORY"):
+            if self.client._adlfs.exists(self.rpath) and \
+               self.client._adlfs.info(self.rpath)['type'] == "DIRECTORY":
                 rfiles = [self.rpath / AzureDLPath(lfiles[0]).name]
             else:
                 rfiles = [self.rpath]

--- a/azure/datalake/store/transfer.py
+++ b/azure/datalake/store/transfer.py
@@ -231,7 +231,6 @@ class ADLTransferClient(object):
         self._merge = merge
         self._nthreads = max(1, nthreads or multiprocessing.cpu_count())
         self._chunksize = chunksize
-        self._chunkretries = 5
         self._buffersize = buffersize
         self._blocksize = blocksize
         self._chunked = chunked

--- a/azure/datalake/store/transfer.py
+++ b/azure/datalake/store/transfer.py
@@ -431,6 +431,16 @@ class ADLTransferClient(object):
         before_start = None
         if monitor:
             self.monitor()
+            for f in self.progress:
+                for chunk in f.chunks:
+                    if chunk.exception:
+                        logger.error('{} -> {}, chunk {} {}: {}, {}'.format(
+                            f.src, f.dst, chunk.name, chunk.offset,
+                            chunk.state, chunk.exception))
+                    elif chunk.state != 'finished':
+                        logger.error('{} -> {}, chunk {} {}: {}'.format(
+                            f.src, f.dst, chunk.name, chunk.offset,
+                            chunk.state))
 
     def _wait(self, poll=0.1, timeout=0):
         start = time.time()

--- a/azure/datalake/store/transfer.py
+++ b/azure/datalake/store/transfer.py
@@ -21,6 +21,8 @@ import threading
 import time
 import uuid
 
+from .exceptions import DatalakeIncompleteTransferException
+
 logger = logging.getLogger(__name__)
 
 
@@ -349,7 +351,11 @@ class ADLTransferClient(object):
                 if exception:
                     cstates[obj] = 'errored'
                 elif self._chunks[obj]['expected'] != nbytes:
+                    src, dst = parent
                     cstates[obj] = 'errored'
+                    self._chunks[obj]['exception'] = DatalakeIncompleteTransferException(
+                        '%s -> %s: expected %s bytes, transferred %s bytes', src, dst,
+                        self._chunks[obj]['expected'], self._chunks[obj]['actual'])
                 else:
                     cstates[obj] = 'finished'
 

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -66,8 +66,13 @@ def du(path):
     return size
 
 
-def verify(adl, progress, lfile, rfile):
+def verify(instance):
     """ Confirm whether target file matches source file """
+    adl = instance.client._adlfs
+    lfile = instance.lpath
+    rfile = instance.rpath
+
+    print("transfer status :", instance.successful())
     print("local file      :", lfile)
     if os.path.exists(lfile):
         print("local file size :", du(lfile))
@@ -80,25 +85,6 @@ def verify(adl, progress, lfile, rfile):
     else:
         print("remote file size:", None)
 
-    for f in progress:
-        chunks_finished = 0
-        for chunk in f.chunks:
-            if chunk.state == 'finished':
-                chunks_finished += 1
-            elif chunk.exception:
-                print("[{}] file {} -> {}, chunk {} {}: {}".format(
-                    chunk.state, f.src, f.dst, chunk.name, chunk.offset,
-                    chunk.exception))
-            else:
-                print("[{}] file {} -> {}, chunk {} {}".format(
-                    chunk.state, f.src, f.dst, chunk.name, chunk.offset))
-        if f.exception:
-            print("[{:4d}/{:4d} chunks] {} -> {}: {}".format(
-                chunks_finished, len(f.chunks), f.src, f.dst, f.exception))
-        else:
-            print("[{:4d}/{:4d} chunks] {} -> {}".format(
-                chunks_finished, len(f.chunks), f.src, f.dst))
-
 
 @benchmark
 def bench_upload_1_50gb(adl, lpath, rpath, config):
@@ -108,7 +94,7 @@ def bench_upload_1_50gb(adl, lpath, rpath, config):
         rpath=rpath,
         **config[bench_upload_1_50gb.__name__])
 
-    verify(adl, up.client.progress, lpath, rpath)
+    verify(up)
 
 
 @benchmark
@@ -119,7 +105,7 @@ def bench_upload_50_1gb(adl, lpath, rpath, config):
         rpath=rpath,
         **config[bench_upload_50_1gb.__name__])
 
-    verify(adl, up.client.progress, lpath, rpath)
+    verify(up)
 
 
 @benchmark
@@ -130,7 +116,7 @@ def bench_download_1_50gb(adl, lpath, rpath, config):
         rpath=rpath,
         **config[bench_download_1_50gb.__name__])
 
-    verify(adl, down.client.progress, lpath, rpath)
+    verify(up)
 
 
 @benchmark
@@ -141,7 +127,7 @@ def bench_download_50_1gb(adl, lpath, rpath, config):
         rpath=rpath,
         **config[bench_download_50_1gb.__name__])
 
-    verify(adl, down.client.progress, lpath, rpath)
+    verify(up)
 
 
 if __name__ == '__main__':

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -72,7 +72,7 @@ def verify(instance):
     lfile = instance.lpath
     rfile = instance.rpath
 
-    print("transfer status :", instance.successful())
+    print("finish w/o error:", instance.successful())
     print("local file      :", lfile)
     if os.path.exists(lfile):
         print("local file size :", du(lfile))
@@ -116,7 +116,7 @@ def bench_download_1_50gb(adl, lpath, rpath, config):
         rpath=rpath,
         **config[bench_download_1_50gb.__name__])
 
-    verify(up)
+    verify(down)
 
 
 @benchmark
@@ -127,7 +127,7 @@ def bench_download_50_1gb(adl, lpath, rpath, config):
         rpath=rpath,
         **config[bench_download_50_1gb.__name__])
 
-    verify(up)
+    verify(down)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When a thread completes, we check if all bytes in a chunk are transferred. If not, we internally recorded an error, but failed to make it aware to the user. This was the source of the silent error.

To prevent future regressions, I added a final step after transfer that will show all errors to the user. I also added a method to check the success of a transfer: `successful()`. This allows a user to manually check the transfer success.

Fixes #108.