### PR TITLE
Set Verbose to false by default

### DIFF
--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -100,7 +100,7 @@ class ADLDownloader(object):
     """
     def __init__(self, adlfs, rpath, lpath, nthreads=None, chunksize=2**28,
                  buffersize=2**22, blocksize=2**22, client=None, run=True,
-                 overwrite=False, verbose=True):
+                 overwrite=False, verbose=False):
         if not overwrite and os.path.exists(lpath):
             raise FileExistsError(lpath)
         if client:
@@ -315,7 +315,7 @@ class ADLUploader(object):
     """
     def __init__(self, adlfs, rpath, lpath, nthreads=None, chunksize=2**28,
                  buffersize=2**22, blocksize=2**22, client=None, run=True,
-                 overwrite=False, verbose=True):
+                 overwrite=False, verbose=False):
         if not overwrite and adlfs.exists(rpath):
             raise FileExistsError(rpath)
         

--- a/azure/datalake/store/transfer.py
+++ b/azure/datalake/store/transfer.py
@@ -227,7 +227,7 @@ class ADLTransferClient(object):
     def __init__(self, adlfs, transfer, merge=None, nthreads=None,
                  chunksize=2**28, blocksize=2**25, chunked=True,
                  unique_temporary=True, delimiter=None,
-                 parent=None, verbose=True, buffersize=2**25):
+                 parent=None, verbose=False, buffersize=2**25):
         self._adlfs = adlfs
         self._parent = parent
         self._transfer = transfer


### PR DESCRIPTION
This means that progress tracking is not captured by default, but it
also means more performant uploads and downloads due to issue:
https://github.com/Azure/azure-data-lake-store-python/issues/142
Once that issue is resolved progress tracking should be supported/on by
default.