### PR TITLE
Work around for issue with pyOpenSSL

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ Release History
 ===============
 0.0.9 (2017-05-09)
 ------------------
-* Enforce basic SSL utilization to ensure performance due to github issue: https://github.com/pyca/pyopenssl/issues/625
+* Enforce basic SSL utilization to ensure performance due to `GitHub issue 625 <https://github.com/pyca/pyopenssl/issues/625>`
 
 0.0.8 (2017-04-26)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.0.9 (2017-05-09)
+------------------
+* Enforce basic SSL utilization to ensure performance due to github issue: https://github.com/pyca/pyopenssl/issues/625
+
 0.0.8 (2017-04-26)
 ------------------
 * Fix server-side throttling retry support. This is not a guarantee that if the server is throttling the upload (or download) it will eventually succeed, but there is now a back-off retry in place to make it more likely.

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -30,8 +30,13 @@ try:
     from requests.packages.urllib3.contrib.pyopenssl import extract_from_urllib3 as enforce_no_py_open_ssl
     enforce_no_py_open_ssl()
 except ImportError:
-    # if OpenSSL is unavailable an import error will occur and that is ok.
-    pass
+    # in the case of debian/ubuntu system packages, the import is slightly different
+    try:
+        from urllib3.contrib.pyopenssl import extract_from_urllib3 as enforce_no_py_open_ssl
+        enforce_no_py_open_ssl()
+    except ImportError:
+        # if OpenSSL is unavailable in both cases then there is no need to "undo" it.
+        pass
 
 from msrest.authentication import Authentication
 from .exceptions import DatalakeBadOffsetException, DatalakeRESTException

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -25,6 +25,14 @@ import adal
 import requests
 import requests.exceptions
 
+# this is required due to github issue, to ensure we don't lose perf from openPySSL: https://github.com/pyca/pyopenssl/issues/625
+try:
+    from requests.packages.urllib3.contrib.pyopenssl import extract_from_urllib3 as enforce_no_py_open_ssl
+    enforce_no_py_open_ssl()
+except ImportError:
+    # if OpenSSL is unavailable an import error will occur and that is ok.
+    pass
+
 from msrest.authentication import Authentication
 from .exceptions import DatalakeBadOffsetException, DatalakeRESTException
 from .exceptions import FileNotFoundError, PermissionError


### PR DESCRIPTION
Issue:  https://github.com/pyca/pyopenssl/issues/625 causes a
perf issue in our SDK when pyOpenSSL is installed. 
This workaround allows us to ensure that we do not use pyOpenSSL when it is installed until the above mentioned issue is investigated and resolved.