### PR TITLE
Minor code cleanup change.

### DIFF
--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -26,17 +26,19 @@ import requests
 import requests.exceptions
 
 # this is required due to github issue, to ensure we don't lose perf from openPySSL: https://github.com/pyca/pyopenssl/issues/625
+enforce_no_py_open_ssl = None
 try:
     from requests.packages.urllib3.contrib.pyopenssl import extract_from_urllib3 as enforce_no_py_open_ssl
-    enforce_no_py_open_ssl()
 except ImportError:
     # in the case of debian/ubuntu system packages, the import is slightly different
     try:
         from urllib3.contrib.pyopenssl import extract_from_urllib3 as enforce_no_py_open_ssl
-        enforce_no_py_open_ssl()
     except ImportError:
         # if OpenSSL is unavailable in both cases then there is no need to "undo" it.
         pass
+
+if enforce_no_py_open_ssl:
+    enforce_no_py_open_ssl()
 
 from msrest.authentication import Authentication
 from .exceptions import DatalakeBadOffsetException, DatalakeRESTException


### PR DESCRIPTION
Reduction of variable calls for enforcing_no_py_open_ssl() which makes
it easier to read.