### PR TITLE
Fix regression and add a test

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.0.12 (2017-06-20)
+-------------------
+* Fix a regression with ls returning the top level folder if it has no contents. It now properly returns an empty array if a folder has no children.
+
 0.0.11 (2017-06-02)
 -------------------
 * Update to name incomplete file downloads with a `.inprogress` suffix. This suffix is removed when the download completes successfully.

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader

--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -130,7 +130,8 @@ class AzureDLFileSystem(object):
             # in this case we just invalidated the cache (if it was true), so no need to do it again
             inf = self.info(path, invalidate_cache=False)
             if inf['type'] == 'DIRECTORY':
-                return inf if detail else []
+                # always return an empty array in this case, because there are no entries underneath the folder
+                return []
 
             raise FileNotFoundError(path)
         if detail:

--- a/tests/recordings/test_core/test_ls_empty_with_details.yaml
+++ b/tests/recordings/test_core/test_ls_empty_with_details.yaml
@@ -1,0 +1,133 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
+          Azure-Data-Lake-Store-SDK-For-Python]
+      x-ms-client-request-id: [171b8cba-55ff-11e7-8a94-645106422854]
+    method: GET
+    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir?OP=LISTSTATUS&api-version=2016-11-01
+  response:
+    body: {string: '{"FileStatuses":{"FileStatus":[{"length":0,"pathSuffix":"foo","type":"DIRECTORY","blockSize":0,"accessTime":1496434282778,"modificationTime":1496434474973,"replication":0,"permission":"770","owner":"9a23860e-03b0-4bad-a8b7-e1d081d592bd","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false}]}}'}
+    headers:
+      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
+      Content-Length: ['302']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 20 Jun 2017 21:26:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Status: ['0x0']
+      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-request-id: [6afecbc3-538e-485b-9af1-f95b82bc2c09]
+      x-ms-webhdfs-version: [17.04.22.00]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
+          Azure-Data-Lake-Store-SDK-For-Python]
+      x-ms-client-request-id: [175423c2-55ff-11e7-a1c4-645106422854]
+    method: GET
+    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir/foo?OP=GETFILESTATUS&api-version=2016-11-01
+  response:
+    body: {string: '{"FileStatus":{"length":0,"pathSuffix":"","type":"DIRECTORY","blockSize":0,"accessTime":1496434282778,"modificationTime":1496434474973,"replication":0,"permission":"770","owner":"9a23860e-03b0-4bad-a8b7-e1d081d592bd","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false}}'}
+    headers:
+      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
+      Content-Length: ['280']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 20 Jun 2017 21:26:14 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Status: ['0x0']
+      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-request-id: [1ac780cd-cae6-4415-9984-24f92412dd82]
+      x-ms-webhdfs-version: [17.04.22.00]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
+          Azure-Data-Lake-Store-SDK-For-Python]
+      x-ms-client-request-id: [179a615e-55ff-11e7-b6f3-645106422854]
+    method: DELETE
+    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir/foo?OP=DELETE&api-version=2016-11-01&recursive=True
+  response:
+    body: {string: '{"boolean":true}'}
+    headers:
+      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
+      Content-Length: ['16']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 20 Jun 2017 21:26:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Status: ['0x0']
+      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-request-id: [b3dac131-edc3-4c67-b8a8-ab09ca5a4d53]
+      x-ms-webhdfs-version: [17.04.22.00]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
+          Azure-Data-Lake-Store-SDK-For-Python]
+      x-ms-client-request-id: [f54736a8-55ff-11e7-b9e0-645106422854]
+    method: GET
+    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir?OP=LISTSTATUS&api-version=2016-11-01
+  response:
+    body: {string: '{"FileStatuses":{"FileStatus":[]}}'}
+    headers:
+      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
+      Content-Length: ['34']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 20 Jun 2017 21:32:27 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Status: ['0x0']
+      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-request-id: [d8fb3281-f8ed-40a2-82dc-e2874170d04e]
+      x-ms-webhdfs-version: [17.04.22.00]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
+          Azure-Data-Lake-Store-SDK-For-Python]
+      x-ms-client-request-id: [f57dad52-55ff-11e7-b477-645106422854]
+    method: GET
+    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/.?OP=LISTSTATUS&api-version=2016-11-01
+  response:
+    body: {string: '{"FileStatuses":{"FileStatus":[{"length":0,"pathSuffix":"azure_test_dir","type":"DIRECTORY","blockSize":0,"accessTime":1496425171191,"modificationTime":1497993975994,"replication":0,"permission":"770","owner":"9a23860e-03b0-4bad-a8b7-e1d081d592bd","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false},{"length":0,"pathSuffix":"catalog","type":"DIRECTORY","blockSize":0,"accessTime":1496786396463,"modificationTime":1496786396485,"replication":0,"permission":"771","owner":"2e6c02d2-a364-4530-9137-d17403996cbf","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false},{"length":0,"pathSuffix":"system","type":"DIRECTORY","blockSize":0,"accessTime":1496786397509,"modificationTime":1496786486323,"replication":0,"permission":"770","owner":"2e6c02d2-a364-4530-9137-d17403996cbf","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false},{"length":0,"pathSuffix":"tmp","type":"DIRECTORY","blockSize":0,"accessTime":1496428506492,"modificationTime":1496428506492,"replication":0,"permission":"770","owner":"9a23860e-03b0-4bad-a8b7-e1d081d592bd","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false}]}}'}
+    headers:
+      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
+      Content-Length: ['1127']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 20 Jun 2017 21:32:28 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Status: ['0x0']
+      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-request-id: [cf855776-0753-4f54-9404-f8c4727a5b47]
+      x-ms-webhdfs-version: [17.04.22.00]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/recordings/test_core/test_ls_empty_with_details.yaml
+++ b/tests/recordings/test_core/test_ls_empty_with_details.yaml
@@ -7,86 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
           Azure-Data-Lake-Store-SDK-For-Python]
-      x-ms-client-request-id: [171b8cba-55ff-11e7-8a94-645106422854]
-    method: GET
-    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir?OP=LISTSTATUS&api-version=2016-11-01
-  response:
-    body: {string: '{"FileStatuses":{"FileStatus":[{"length":0,"pathSuffix":"foo","type":"DIRECTORY","blockSize":0,"accessTime":1496434282778,"modificationTime":1496434474973,"replication":0,"permission":"770","owner":"9a23860e-03b0-4bad-a8b7-e1d081d592bd","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false}]}}'}
-    headers:
-      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
-      Content-Length: ['302']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 20 Jun 2017 21:26:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Status: ['0x0']
-      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
-      X-Content-Type-Options: [nosniff]
-      x-ms-request-id: [6afecbc3-538e-485b-9af1-f95b82bc2c09]
-      x-ms-webhdfs-version: [17.04.22.00]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
-          Azure-Data-Lake-Store-SDK-For-Python]
-      x-ms-client-request-id: [175423c2-55ff-11e7-a1c4-645106422854]
-    method: GET
-    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir/foo?OP=GETFILESTATUS&api-version=2016-11-01
-  response:
-    body: {string: '{"FileStatus":{"length":0,"pathSuffix":"","type":"DIRECTORY","blockSize":0,"accessTime":1496434282778,"modificationTime":1496434474973,"replication":0,"permission":"770","owner":"9a23860e-03b0-4bad-a8b7-e1d081d592bd","group":"2e6c02d2-a364-4530-9137-d17403996cbf","aclBit":false}}'}
-    headers:
-      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
-      Content-Length: ['280']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 20 Jun 2017 21:26:14 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Status: ['0x0']
-      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
-      X-Content-Type-Options: [nosniff]
-      x-ms-request-id: [1ac780cd-cae6-4415-9984-24f92412dd82]
-      x-ms-webhdfs-version: [17.04.22.00]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
-          Azure-Data-Lake-Store-SDK-For-Python]
-      x-ms-client-request-id: [179a615e-55ff-11e7-b6f3-645106422854]
-    method: DELETE
-    uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir/foo?OP=DELETE&api-version=2016-11-01&recursive=True
-  response:
-    body: {string: '{"boolean":true}'}
-    headers:
-      Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
-      Content-Length: ['16']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 20 Jun 2017 21:26:15 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Status: ['0x0']
-      Strict-Transport-Security: [max-age=15724800; includeSubDomains]
-      X-Content-Type-Options: [nosniff]
-      x-ms-request-id: [b3dac131-edc3-4c67-b8a8-ab09ca5a4d53]
-      x-ms-webhdfs-version: [17.04.22.00]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
-          Azure-Data-Lake-Store-SDK-For-Python]
-      x-ms-client-request-id: [f54736a8-55ff-11e7-b9e0-645106422854]
+      x-ms-client-request-id: [3a91b06e-5602-11e7-9f13-645106422854]
     method: GET
     uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/azure_test_dir?OP=LISTSTATUS&api-version=2016-11-01
   response:
@@ -95,13 +16,13 @@ interactions:
       Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
       Content-Length: ['34']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 20 Jun 2017 21:32:27 GMT']
+      Date: ['Tue, 20 Jun 2017 21:48:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Status: ['0x0']
       Strict-Transport-Security: [max-age=15724800; includeSubDomains]
       X-Content-Type-Options: [nosniff]
-      x-ms-request-id: [d8fb3281-f8ed-40a2-82dc-e2874170d04e]
+      x-ms-request-id: [d4083d2e-fc96-4513-b40c-66c1de239ffa]
       x-ms-webhdfs-version: [17.04.22.00]
     status: {code: 200, message: OK}
 - request:
@@ -112,7 +33,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python/3.6.1 (Windows-10-10.0.15063-SP0) azure.datalake.store.lib/0.0.12
           Azure-Data-Lake-Store-SDK-For-Python]
-      x-ms-client-request-id: [f57dad52-55ff-11e7-b477-645106422854]
+      x-ms-client-request-id: [3b226d30-5602-11e7-989f-645106422854]
     method: GET
     uri: https://fakestore.azuredatalakestore.net/webhdfs/v1/.?OP=LISTSTATUS&api-version=2016-11-01
   response:
@@ -121,13 +42,13 @@ interactions:
       Cache-Control: ['no-cache, no-cache, no-store, max-age=0']
       Content-Length: ['1127']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Tue, 20 Jun 2017 21:32:28 GMT']
+      Date: ['Tue, 20 Jun 2017 21:48:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Status: ['0x0']
       Strict-Transport-Security: [max-age=15724800; includeSubDomains]
       X-Content-Type-Options: [nosniff]
-      x-ms-request-id: [cf855776-0753-4f54-9404-f8c4727a5b47]
+      x-ms-request-id: [dc636abc-dd06-4552-b0b6-e009bbac7b85]
       x-ms-webhdfs-version: [17.04.22.00]
     status: {code: 200, message: OK}
 version: 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -56,6 +56,11 @@ def test_ls_touch(azure):
         assert set(L) == set([a, b])
 
 @my_vcr.use_cassette
+def test_ls_empty_with_details(azure):
+    with azure_teardown(azure):
+        assert not azure.ls(test_dir, invalidate_cache=False, detail=True)
+
+@my_vcr.use_cassette
 def test_ls_touch_invalidate_cache(azure, second_azure):
     with azure_teardown(azure):
         assert not azure.ls(test_dir, invalidate_cache=False)


### PR DESCRIPTION
This fixes a regression when showing details. We should always return an
empty array even if details are asked for, when an ls call has no
children to return.