### PR TITLE
Add ServicePrincipal token refresh support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.0.13 (2017-06-28)
+-------------------
+* Add support for automatic refreshing of service principal credentials
+
 0.0.12 (2017-06-20)
 -------------------
 * Fix a regression with ls returning the top level folder if it has no contents. It now properly returns an empty array if a folder has no children.

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -172,7 +172,7 @@ class DataLakeCredential(Authentication):
 
         context = adal.AuthenticationContext(authority +
                                              self.token['tenant'])
-        if self.token['secret'] and self.token['client']:
+        if self.token.get('secret') and self.token.get('client'):
             out = context.acquire_token_with_client_credentials(self.token['resource'], self.token['client'],
                                                                 self.token['secret'])
             out.update({'secret': self.token['secret']})

--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -61,6 +61,9 @@ MAX_CONTENT_LENGTH = 2**16
 # This ensures that no connections are prematurely evicted, which has negative performance implications.
 MAX_POOL_CONNECTIONS = 1024
 
+# TODO: a breaking change should be made to add a new parameter specific for service_principal_app_id
+# instead of overloading client_id, which is also used by other login methods to indicate what application
+# is requesting the authentication (for example, in an interactive prompt).
 def auth(tenant_id=None, username=None,
          password=None, client_id=default_client,
          client_secret=None, resource=DEFAULT_RESOURCE_ENDPOINT,
@@ -128,6 +131,8 @@ def auth(tenant_id=None, username=None,
     elif client_id and client_secret:
         out = context.acquire_token_with_client_credentials(resource, client_id,
                                                             client_secret)
+        # for service principal, we store the secret in the credential object for use when refreshing.
+        out.update({'secret': client_secret})
     else:
         raise ValueError("No authentication method found for credentials")
 
@@ -159,7 +164,7 @@ class DataLakeCredential(Authentication):
         authority: string
             The full URI of the authentication authority to authenticate against (such as https://login.microsoftonline.com/)
         """
-        if self.token.get('refresh', False) is False:
+        if self.token.get('refresh', False) is False and (not self.token['secret'] or not self.token['client']):
             raise ValueError("Token cannot be auto-refreshed.")
 
         if not authority:
@@ -167,10 +172,17 @@ class DataLakeCredential(Authentication):
 
         context = adal.AuthenticationContext(authority +
                                              self.token['tenant'])
-        out = context.acquire_token_with_refresh_token(self.token['refresh'],
-                                                       client_id=self.token['client'],
-                                                       resource=self.token['resource'])
-        out.update({'access': out['accessToken'], 'refresh': out['refreshToken'],
+        if self.token['secret'] and self.token['client']:
+            out = context.acquire_token_with_client_credentials(self.token['resource'], self.token['client'],
+                                                                self.token['secret'])
+            out.update({'secret': self.token['secret']})
+        else:
+            out = context.acquire_token_with_refresh_token(self.token['refresh'],
+                                                           client_id=self.token['client'],
+                                                           resource=self.token['resource'])
+            out.update({'refresh': out['refreshToken']})
+        # common items to update
+        out.update({'access': out['accessToken'],
                     'time': time.time(), 'tenant': self.token['tenant'],
                     'resource': self.token['resource'], 'client': self.token['client']})
     

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ To run the test suite against a local build:
     
     python setup.py develop
     
-    py.test -x -vvv --doctest-modules --pyargs azure.datalake.store tests
+    py.test -x -vvv --doctest-modules --pyargs azure-datalake-store tests
     
 This test suite uses [VCR.py](https://github.com/kevin1024/vcrpy) to record the
 responses from Azure. Borrowing from VCR's
@@ -31,5 +31,8 @@ environment variables should be defined:
 * `azure_data_lake_store_name`
 * `azure_subscription_id`
 * `azure_resource_group_name`
+* `azure_service_principal`
+* `azure_service_principal_secret`
+* `azure_tenant_id`
 
 Optionally, you may need to define `azure_tenant_id` or `azure_url_suffix`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,12 @@
 To run the test suite against the published package:
 
-    py.test -x -vvv --doctest-modules --pyargs azure-datalake-store tests
+    py.test -x -vvv --doctest-modules --pyargs azure.datalake.store tests
 
 To run the test suite against a local build:
     
     python setup.py develop
     
-    py.test -x -vvv --doctest-modules --pyargs azure-datalake-store tests
+    py.test -x -vvv --doctest-modules --pyargs azure.datalake.store tests
     
 This test suite uses [VCR.py](https://github.com/kevin1024/vcrpy) to record the
 responses from Azure. Borrowing from VCR's

--- a/tests/recordings/test_lib/test_auth_refresh_for_service_principal.yaml
+++ b/tests/recordings/test_lib/test_auth_refresh_for_service_principal.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: grant_type=client_credentials&client_id=4c166e66-85a9-4106-9e96-10fd941458cf&resource=https%3A%2F%2Fmanagement.core.windows.net%2F&client_secret=HA3yMEUra%2Bt6O%2Fo8e47rFUe5LRYAx8VSr%2F4iFSesGtA%3D
+    headers:
+      Accept: ['*/*']
+      Accept-Charset: [utf-8]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['197']
+      User-Agent: [python-requests/2.18.1]
+      client-request-id: [56e173c1-b467-4e0b-8f86-66dacfe2b28e]
+      content-type: [application/x-www-form-urlencoded]
+      return-client-request-id: ['true']
+      x-client-CPU: [x64]
+      x-client-OS: [win32]
+      x-client-SKU: [Python]
+      x-client-Ver: [0.4.5]
+    method: POST
+    uri: https://login.microsoftonline.com/faketenant/oauth2/token?api-version=1.0
+  response:
+    body: {string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"262800","expires_on":"1498701441","not_before":"1498697541","resource":"https://management.core.windows.net/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlGWERwYmZNRlQyU3ZRdVhoODQ2WVR3RUlCdyIsImtpZCI6IjlGWERwYmZNRlQyU3ZRdVhoODQ2WVR3RUlCdyJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuY29yZS53aW5kb3dzLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC82ZTYwNmVjZS0zYTVhLTQ2NzQtYTY1NC1kNmIwMmJjNWE1MWIvIiwiaWF0IjoxNDk4Njk3NTQxLCJuYmYiOjE0OTg2OTc1NDEsImV4cCI6MTQ5ODcwMTQ0MSwiYWlvIjoiWTJaZ1lPZ1RpcHJyWGg2cmRqSWxRemdnM01rWkFBPT0iLCJhcHBpZCI6IjRjMTY2ZTY2LTg1YTktNDEwNi05ZTk2LTEwZmQ5NDE0NThjZiIsImFwcGlkYWNyIjoiMSIsImVfZXhwIjoyNjI4MDAsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzZlNjA2ZWNlLTNhNWEtNDY3NC1hNjU0LWQ2YjAyYmM1YTUxYi8iLCJvaWQiOiI2MGY4NTkxYy0wZDg2LTRkM2EtOGM0Mi05ODU4ZmMwMWY3ZmIiLCJzdWIiOiI2MGY4NTkxYy0wZDg2LTRkM2EtOGM0Mi05ODU4ZmMwMWY3ZmIiLCJ0aWQiOiI2ZTYwNmVjZS0zYTVhLTQ2NzQtYTY1NC1kNmIwMmJjNWE1MWIiLCJ2ZXIiOiIxLjAifQ.DRr63pOO4J6BCvYtkIkcvRNqQzPkIntlDncoPEy5QWb9l4lisFDPOKXLPsOVLm8_t3hOEk1wbxbgTZRCItzaLc56BEbKY-cg669ObmkGSK-UcVGs8d2UJxb6Ihm09e4KiAZZaNwEdeW9nR6vBSdOxxMhkAfJ9vhLScYzBvpBrslsJaxWA0PiAITFIS9yQUIdaJjklibxnWYnCKGbt19r2vTkojP4jIfIcZ1L2ZjcP854H-WS4W6vIzDJPhjBLb-4C3_zTAnvRoAIEPNI4S0KIHXSWVA20AanDvZnz1m8X-vTPhrHJb2YChefX2UE2TZfVxHaXOBkS3SbPqs2ajt8oQ"}'}
+    headers:
+      Cache-Control: ['no-cache, no-store']
+      Content-Length: ['1335']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 29 Jun 2017 00:57:23 GMT']
+      Expires: ['-1']
+      P3P: [CP="DSP CUR OTPi IND OTRi ONL FIN"]
+      Pragma: [no-cache]
+      Server: [Microsoft-IIS/8.5]
+      Set-Cookie: [esctx=AQABAAAAAABnfiG-mA6NTae7CdWW7QfdYAFoYcRXRIqOoHEaiXwESTEMfP_sgMYS7xHVQ5D6uU3UtDm325Q8UZzKvstd1EujTtO-TZqkCCR-LIQx2Q8ChXeaQjMCj-CnrfS-avlDydH0XLol99inGkw4-x4b9mNA2vqt0LRrV5xgtQOUdv5LWRrsjKwpm7YWyZcMl20Sgs0gAA;
+          domain=.login.microsoftonline.com; path=/; secure; HttpOnly, x-ms-gateway-slice=corp;
+          path=/; secure; HttpOnly, stsservicecookie=ests; path=/; secure; HttpOnly]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      X-Powered-By: [ASP.NET]
+      client-request-id: [56e173c1-b467-4e0b-8f86-66dacfe2b28e]
+      x-ms-request-id: [3641a78b-788f-4eca-bac8-275055060000]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,11 +29,35 @@ if RECORD_MODE == 'none':
             tokenType='Bearer'))
     SUBSCRIPTION_ID = fake_settings.SUBSCRIPTION_ID
     RESOURCE_GROUP_NAME = fake_settings.RESOURCE_GROUP_NAME
+    PRINCIPAL_TOKEN = DataLakeCredential(
+        dict(
+            access=str(base64.b64encode(os.urandom(1420))),
+            client='e6f90497-409b-4a4e-81f2-8cede2fe6a65', # arbitrary guid.
+            secret=str(base64.b64encode(os.urandom(1420))),
+            refresh=None,
+            time=time.time(),
+            resource="https://management.core.windows.net/",
+            tenant=TENANT_ID, expiresIn=3600,
+            tokenType='Bearer'))
 else:
     STORE_NAME = os.environ['azure_data_lake_store_name']
     TENANT_ID = os.environ.get('azure_tenant_id', 'common')
     TOKEN = auth(TENANT_ID,
                  os.environ['azure_username'],
                  os.environ['azure_password'])
+    # set the environment variable to empty to avoid confusion in auth
+    to_reset_user = os.environ.pop('azure_username', None)
+    to_reset_pass = os.environ.pop('azure_password', None)
+    
+    PRINCIPAL_TOKEN = auth(TENANT_ID,
+                           client_id=os.environ['azure_service_principal'],
+                           client_secret=os.environ['azure_service_principal_secret'])
+
+    # set it back after auth.
+    if to_reset_pass:
+        os.environ['azure_password'] = to_reset_pass
+    if to_reset_user:
+        os.environ['azure_username'] = to_reset_user
+
     SUBSCRIPTION_ID = os.environ['azure_subscription_id']
     RESOURCE_GROUP_NAME = os.environ['azure_resource_group_name']


### PR DESCRIPTION
This change addresses issue: https://github.com/Azure/azure-data-lake-store-python/issues/165 and adds a quality of life improvement to automatically refresh service principal credentials when they expire within the client, removing that responsibility from the caller of the SDK.