### PR TITLE
Race condition due to `transfer` future `done_callback` that depends on state that may set after it's execution #177

### DIFF
--- a/azure/datalake/store/transfer.py
+++ b/azure/datalake/store/transfer.py
@@ -302,12 +302,6 @@ class ADLTransferClient(object):
             "exception": None}
 
 
-    def _submit(self, fn, *args, **kwargs):
-        kwargs['shutdown_event'] = self._shutdown_event
-        future = self._pool.submit(fn, *args, **kwargs)
-        future.add_done_callback(self._update)
-        return future
-
     def _start(self, src, dst):
         key = (src, dst)
         self._fstates[key] = 'transferring'
@@ -317,11 +311,12 @@ class ADLTransferClient(object):
             if obj in cs.objects and cs[obj] == 'finished':
                 continue
             cs[obj] = 'running'
-            future = self._submit(
+            future = self._pool.submit(
                 self._transfer, self._adlfs, src, name, offset,
                 self._chunks[obj]['expected'], self._buffersize,
-                self._blocksize)
+                self._blocksize, shutdown_event=self._shutdown_event)
             self._cfutures[future] = obj
+            future.add_done_callback(self._update)
 
     @property
     def active(self):
@@ -455,6 +450,9 @@ class ADLTransferClient(object):
         # TODO: Re-enable progress saving when a less IO intensive solution is available.
         # See issue: https://github.com/Azure/azure-data-lake-store-python/issues/117
         #self.save()
+        else:
+            raise ValueError("Illegal state future {} not found in either file futures {} nor chunk futures {}"
+                             .format(future, self._ffutures, self._cfutures))
         if self.verbose:
             print('\b' * 200, self.status, end='')
             sys.stdout.flush()

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -16,7 +16,6 @@ from tests.testing import azure, posix
 
 def test_shutdown(azure):
     def transfer(adlfs, src, dst, offset, size, blocksize, buffersize, retries=5, shutdown_event=None):
-        time.sleep(1.0)
         while shutdown_event and not shutdown_event.is_set():
             time.sleep(0.1)
         return size, None
@@ -25,7 +24,6 @@ def test_shutdown(azure):
                                chunked=False)
     client.submit('foo', 'bar', 16)
     client.run(monitor=False)
-    time.sleep(0.1)
     client.shutdown()
 
     assert client.progress[0].state == 'finished'
@@ -33,7 +31,6 @@ def test_shutdown(azure):
 
 def test_submit_and_run(azure):
     def transfer(adlfs, src, dst, offset, size, blocksize, buffersize, shutdown_event=None):
-        time.sleep(0.1)
         return size, None
 
     client = ADLTransferClient(azure, transfer=transfer, chunksize=8,
@@ -65,7 +62,6 @@ def test_submit_and_run(azure):
 
 def test_temporary_path(azure):
     def transfer(adlfs, src, dst, offset, size, blocksize, buffersize):
-        time.sleep(0.1)
         return size, None
 
     client = ADLTransferClient(azure, transfer=transfer, chunksize=8,


### PR DESCRIPTION


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [ ] Links to associated bugs, if any, are in the description.
