### PR TITLE
Fixed download path relativity issue in case of cross os paths with t…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.23 (2018-07-11)
++++++++++++++++++++
+* Fixed the incorrect download location in case of UNC local paths
+
 0.0.22 (2018-06-02)
 +++++++++++++++++++
 * Encoding filepaths in URI

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader

--- a/azure/datalake/store/multithread.py
+++ b/azure/datalake/store/multithread.py
@@ -195,7 +195,7 @@ class ADLDownloader(object):
         else:
             rfiles = self.client._adlfs.glob(self.rpath, details=True, invalidate_cache=True)
         if len(rfiles) > 1:
-            local_rel_rpath = str(AzureDLPath(self.rpath).globless_prefix)
+            local_rel_rpath = str(AzureDLPath(self.rpath).trim().globless_prefix)
             file_pairs = [(os.path.join(self.lpath, os.path.relpath(f['name'] +'.inprogress', local_rel_rpath)), f)
                           for f in rfiles]
         elif len(rfiles) == 1:

--- a/tests/test_multithread.py
+++ b/tests/test_multithread.py
@@ -142,6 +142,19 @@ def test_download_many(tempdir, azure):
             nfiles += len(filenames)
         assert nfiles > 1
 
+@my_vcr.use_cassette
+def test_download_path(azure):
+    with setup_tree(azure):
+        down = ADLDownloader(
+            azure,
+            lpath="/lpath/test/testfolder",
+            rpath='/' + test_dir.name,
+            run=False)
+        for lfile, rfile in down._file_pairs:
+            if 'data' in lfile:
+                lfile = AzureDLPath(lfile)
+                assert lfile.as_posix().startswith('/lpath/test/testfolder/data')
+
 
 @my_vcr.use_cassette
 def test_download_glob(tempdir, azure):
@@ -150,7 +163,7 @@ def test_download_glob(tempdir, azure):
         down = ADLDownloader(azure, remote_path, tempdir, run=False,
                              overwrite=True)
         file_pair_dict = dict(down._file_pairs)
-        
+
         assert len(file_pair_dict.keys()) == 2
 
         lfiles = [os.path.relpath(f, tempdir) for f in file_pair_dict.keys()]
@@ -344,7 +357,7 @@ def test_upload_glob(tempdir, azure):
 
         rfiles = [posix(AzureDLPath(f).relative_to(test_dir))
                   for f in file_pair_dict.values()]
-        
+
         assert sorted(rfiles) == sorted([posix('a', 'z.txt'), posix('b', 'z.txt')])
 
 


### PR DESCRIPTION
…est case

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change

This PR is about issue#215. We were messing up the path of download location while calculating the relative path. This was mostly due to mismatch in OS based path.
When the directory with more than one file was downloaded and lpath was unc based (starting with /) but called from windows os, we messed up in actual download location.
This PR fixes that.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [x] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [x] Links to associated bugs, if any, are in the description.
