### PR TITLE
Bad offset recovery fix

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.28 (2018-08-020)
++++++++++++++++++++
+* Added recovery from DatalakeBadOffsetException
+
 0.0.27 (2018-08-08)
 +++++++++++++++++++
 * Fixed bug in single file check

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.27"
+__version__ = "0.0.28"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1190,3 +1190,14 @@ def test_forward_slash():
     assert posix(AzureDLPath('/*').globless_prefix) == '/'
     assert posix(AzureDLPath('/foo/*').globless_prefix) == '/foo'
     assert posix(AzureDLPath('/foo/b*').globless_prefix) == '/foo'
+
+
+def test_DatalakeBadOffsetExceptionRecovery(azure):
+    from azure.datalake.store.core import _put_data_with_retry
+    data = b'abc'
+    _put_data_with_retry(azure.azure, 'CREATE', a, data=data)
+    _put_data_with_retry(azure.azure, 'APPEND', a, data=data, offset=len(data))
+    _put_data_with_retry(azure.azure, 'APPEND', a, data=data, offset=len(data))
+    assert azure.cat(a) == data*2
+    _put_data_with_retry(azure.azure, 'APPEND', a, data=data)
+    assert azure.cat(a) == data*3


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change
Adds recovery from DatalakeBadOffsetException, in cases where data write succeeded in the backend, but sdk didn't get the correct response back.
### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [x] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [x] Links to associated bugs, if any, are in the description.
