### PR TITLE
Fix for issue #236

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache: pip
 
 matrix:
   include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
     - python: 3.6
 
 install:
@@ -30,10 +33,11 @@ notifications:
 
 deploy:
   provider: pypi
-  user: random_user_name
+  user: akharit-ms
   skip_upload_docs: true
   # password: use $PYPI_PASSWORD
   distributions: "sdist bdist_wheel"
   on:
+    tags: true
     python: '3.6'
     repo: Azure/azure-data-lake-store-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
   user: akharit-ms
   skip_upload_docs: true
   # password: use $PYPI_PASSWORD
-  distributions: "sdist bdist_wheel"
+  distributions: "bdist_wheel sdist"   # Parameter order for distributions is important.
   on:
     tags: true
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ cache: pip
 
 matrix:
   include:
-    - python: 2.7
-    - python: 3.4
-    - python: 3.5
     - python: 3.6
 
 install:
@@ -33,11 +30,10 @@ notifications:
 
 deploy:
   provider: pypi
-  user: akharit-ms
+  user: random_user_name
   skip_upload_docs: true
   # password: use $PYPI_PASSWORD
   distributions: "sdist bdist_wheel"
   on:
-    tags: true
     python: '3.6'
     repo: Azure/azure-data-lake-store-python

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.30 (2018-08-28)
++++++++++++++++++++
+* Fixed .travis.yml order to add azure-nspg dependency
+
 0.0.29 (2018-08-22)
 +++++++++++++++++++
 * Fixed HISTORY.rst and Pypi documentation

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change
Changing the order of distributions parameter. With the previous order i.e sdist first, the whl package created doesn't have azure-nspkg as dependency. 

This causes imports to fail for Python 2.7(#236 ) due to different import behavior in Python 2 vs 3. 


### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
NA
- [x] Links to associated bugs, if any, are in the description.
