### PR TITLE
Add parameter to set a maximum number of files to download or upload

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.32 (2018-09-12)
++++++++++++++++++++
+* Added parameter to set a maximum number of files to download or upload
+
 0.0.31 (2018-09-10)
 +++++++++++++++++++
 * Added support for batched ls

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.31"
+__version__ = "0.0.32"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader


### PR DESCRIPTION
### Description of the change
Added the `nfiles` parameter to the `ADLDownloader` and `ADLUploader` classes in order to set an upper bound to the files that are transferred.

This is simply done by cutting the list of files that is internally generated by the `glob` or the `walk` function; if the parameter is not set (default to `None`) the list won't be cropped (`any_list[:None]` is `any_list`).

### Further improvement
A further improvement could be to allow the user to directly provide a list instead of a path (so moving the `glob`,  `walk`, `ls` or *custom list creation* effort to the user side), resulting in a better flexibility.

### General Guidelines
- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [x] Links to associated bugs, if any, are in the description.
