### PR TITLE
Fix for Chunked Decoding exception thrown while reading response.content

### DIFF
--- a/azure/datalake/store/lib.py
+++ b/azure/datalake/store/lib.py
@@ -414,6 +414,8 @@ class DatalakeRESTInterface:
                                             path=path,
                                             headers=headers,
                                             **kwargs)
+                # Trigger download here so any errors can be retried. response.content is cached for future use.
+                temp_download = response.content
             except requests.exceptions.RequestException as e:
                 last_exception = e
                 response = None


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change
Triggers early download of response.content so it can be retried in case a connection drops in middle of reading the stream.
### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
Will be done when merge to master.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings
NA.
- [ ] Links to associated bugs, if any, are in the description.
NA