### PR TITLE
Fix flush and open

### DIFF
--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -915,7 +915,7 @@ class AzureDLFile(object):
         location of file
     mode : str {'wb', 'rb', 'ab'}
     blocksize : int
-        Size of the write or read-ahead buffer. For writing, will be
+        Size of the write or read-ahead buffer. For writing(and appending, will be
         truncated to 4MB (2**22).
     delimiter : bytes or None
         If specified and in write mode, each flush will send data terminating
@@ -981,6 +981,7 @@ class AzureDLFile(object):
                 syncFlag='DATA',
                 leaseid=self.leaseid,
                 filesessionid=self.filesessionid)
+            logger.debug('Created file %s ' % self.path)
         else: # mode == 'rb':
             if not exists:
                 raise FileNotFoundError(path.as_posix())

--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -1208,13 +1208,13 @@ class AzureDLFile(object):
                     data_to_write_limit = delimiter_index + len(self.delimiter)
 
             offset = self.tell() - len(data)
-            _put_data_with_retry(**common_args_append, syncFlag='DATA', data=data[:data_to_write_limit], offset=offset)
+            _put_data_with_retry(syncFlag='DATA', data=data[:data_to_write_limit], offset=offset, **common_args_append)
             logger.debug('Wrote %d bytes to %s' % (data_to_write_limit, self))
             data = data[data_to_write_limit:]
 
         if force:
             offset = self.tell() - len(data)
-            _put_data_with_retry(**common_args_append, syncFlag=syncFlag, data=data, offset=offset)
+            _put_data_with_retry(syncFlag=syncFlag, data=data, offset=offset, **common_args_append)
             logger.debug('Wrote %d bytes to %s' % (len(data), self))
             data = b''
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1107,11 +1107,6 @@ def test_closed(azure):
         f.close()
         assert f.closed
 
-        with azure.open(a, "wb", blocksize=4) as f:
-            f.write(b'1234')
-            f.write(b'5678')
-        assert azure.cat(a) == '1234567'
-
 
 @my_vcr.use_cassette
 def test_TextIOWrapper(azure):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1107,6 +1107,11 @@ def test_closed(azure):
         f.close()
         assert f.closed
 
+        with azure.open(a, "wb", blocksize=4) as f:
+            f.write(b'1234')
+            f.write(b'5678')
+        assert azure.cat(a) == '1234567'
+
 
 @my_vcr.use_cassette
 def test_TextIOWrapper(azure):
@@ -1315,3 +1320,15 @@ def test_DatalakeBadOffsetExceptionRecovery(azure):
     assert azure.cat(a) == data*2
     _put_data_with_retry(azure.azure, 'APPEND', a, data=data)
     assert azure.cat(a) == data*3
+
+
+def test_file_creation_open(azure):
+    with azure_teardown(azure):
+        if azure.exists(a):
+            azure.rm(a)
+        assert not azure.exists(a)
+        f = azure.open(a, "wb")
+        assert azure.exists(a)
+        f.close()
+        assert azure.info(a)['length'] == 0
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1137,15 +1137,21 @@ def test_array(azure):
 
 def write_delimited_data(azure, delimiter):
     data = delimiter.join([b'123', b'456', b'789'])
-    data2 = data + delimiter
     with azure.open(a, 'wb', delimiter=delimiter, blocksize=6) as f:
         f.write(b'123' + delimiter)
         assert f.buffer.tell() == 3 + len(delimiter)
-        f.write(b'456' + delimiter) # causes flush
-        f.write(b'789') # causes length to be reflected on server side
-        assert azure.cat(a) == b'123' + delimiter
+        f.write(b'456' + delimiter)                    # causes flush, but will only write till 123 + delimiter
+        assert f.buffer.tell() == 3 + len(delimiter)   # buffer will have b'456' + delimiter
+        f.buffer, temp_buffer = io.BytesIO(), f.buffer # Emptry buffer so flush doesn't write any more data
+        f.loc, temp_loc = 3 + len(delimiter), f.loc    # Fix location.
+        f.flush(force=True) # To Sync metadata. Force is needed as there is no data in buffer
 
-    # close causes forced flush
+        assert azure.cat(a) == b'123' + delimiter
+        f.buffer = temp_buffer
+        f.loc = temp_loc
+        # close causes forced flush
+        f.write(b'789')
+
     assert azure.cat(a) == data
 
 


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change
flush was returning early if buffer is empty, even when called with force flag. Fixed.
Made sure that the delimiter test doesn't require on adls internal behavior.
opening a file required 3 separate calls to getFileStatus. Now it takes only one call.

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
will do when merge to master.
- [x] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [ ] Links to associated bugs, if any, are in the description.
