### PR TITLE
fix: Add positional arguments to NoRetryPolicy.should_retry

### DIFF
--- a/azure/datalake/store/retry.py
+++ b/azure/datalake/store/retry.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class RetryPolicy:
-    def should_retry(self):
+    def should_retry(self, *args):
         pass
 
 


### PR DESCRIPTION
Add positional arguments to `NoRetryPolicy.should_retry`, so that an exception [here](https://github.com/Azure/azure-data-lake-store-python/blob/master/azure/datalake/store/lib.py#L429) will yield the correct behaviour.

Otherwise, the error will be `TypeError: should_retry() takes 1 positional argument but 4 were given` when `NoRetryPolicy` is used.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change

### General Guidelines

- [ ] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [ ] Links to associated bugs, if any, are in the description.
