### PR TITLE
Add source root dir to python path in docs/source/conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
conf.py imports the version from the local module, so it needs to have the
directory in the python path, otherwise it fails with:

$ sphinx-apidoc -f -e -o docs/api azure/datalake/store
Creating file docs/api/store.core.rst.
Creating file docs/api/store.enums.rst.
Creating file docs/api/store.exceptions.rst.
Creating file docs/api/store.lib.rst.
Creating file docs/api/store.multiprocessor.rst.
Creating file docs/api/store.multithread.rst.
Creating file docs/api/store.retry.rst.
Creating file docs/api/store.transfer.rst.
Creating file docs/api/store.utils.rst.
Creating file docs/api/store.rst.
Creating file docs/api/modules.rst.
$ make -C docs man
make: Entering directory '/home/bluca/git/azure-data-lake-store-python/docs'
sphinx-build -b man -d build/doctrees   source build/man
Running Sphinx v1.8.4

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/usr/lib/python3/dist-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/bluca/git/azure-data-lake-store-python/docs/source/conf.py", line 65, in <module>
    import azure.datalake.store
ModuleNotFoundError: No module named 'azure.datalake'

make: *** [Makefile:156: man] Error 2
make: Leaving directory '/home/bluca/git/azure-data-lake-store-python/docs'

---


Same pattern as other Azure Python packages are following, eg:

https://github.com/Azure/azure-cosmos-python/blob/master/doc/conf.py#L21