### PR TITLE
Fix error in retry when adal exception doesn't return response with json

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.50 (2020-09-10)
++++++++++++++++++++
+* Fix bug with retrying for ADAL exception parsing.
+
 0.0.49 (2020-08-05)
 +++++++++++++++++++
 * Fix bug with NoRetryPolicy

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.49"
+__version__ = "0.0.50"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change
Fix adal error when exception doesn't return correct response. ADAL was returning exception where e.error_response was probably an empty string. this happens when ADAL failed to parse the exception. Since this is a GET operation, we can still retry this.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [ ] Links to associated bugs, if any, are in the description.

