### PR TITLE
changed logger verbosity to debug

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.52 (2020-11-25)
++++++++++++++++++++
+* Changed logging verbosity when closing a stream
+
 0.0.51 (2020-10-15)
 +++++++++++++++++++
 * Add more logging for zero byte reads to investigate root cause.

--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -1136,7 +1136,7 @@ class AzureDLFile(object):
             self.cache = b""
             return
         if self.start <= offset < self.end:
-            logger.info("Read offset {offset} is within cache {start}-{end}. "
+            logger.debug("Read offset {offset} is within cache {start}-{end}. "
                         "Not going to server.".format(offset=offset, start=self.start, end=self.end))
             return
         if offset > self.size:
@@ -1285,7 +1285,7 @@ class AzureDLFile(object):
 
         If in write mode, causes flush of any unwritten data.
         """
-        logger.info("closing stream")
+        logger.debug("closing stream")
         if self.closed:
             return
         if self.writable():


### PR DESCRIPTION
### Description of the change

azure/datalake/store/core.py has two logger lines that log with verbosity "info", which should be "debug" (I think). The log of my app is filled with "closing stream" messages for each and every file I open. I feel it does not make sense for a library to log routine tasks with such verbosity.

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings. (n/a?)
- [x] Links to associated bugs, if any, are in the description. (n/a)
