### PR TITLE
Don't invalidate cache when opening files 'rb', speed up small read 2x

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.52 (2020-11-29)
++++++++++++++++++++
+* Don't invalidate cache when opening files with mode rb, speed up small reads 2x.
+
 0.0.51 (2020-10-15)
 +++++++++++++++++++
 * Add more logging for zero byte reads to investigate root cause.

--- a/azure/datalake/store/core.py
+++ b/azure/datalake/store/core.py
@@ -993,7 +993,8 @@ class AzureDLFile(object):
         # always invalidate the cache when checking for existence of a file
         # that may be created or written to (for the first time).
         try:
-            file_data = self.azure.info(path, invalidate_cache=True, expected_error_code=404)
+            invalidate = mode != 'rb'
+            file_data = self.azure.info(path, invalidate_cache=invalidate, expected_error_code=404)
             exists = True
         except FileNotFoundError:
             exists = False


### PR DESCRIPTION
This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change

Don't invalidate cache when opening files 'rb', speed up small read 2x.
This aligns the code with the following comment:

  always invalidate the cache when checking for existence of a file
  that may be created or written to (for the first time).

### General Guidelines

- [*] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [*] Links to associated bugs, if any, are in the description. (n/a)
