### PR TITLE
Suppress urllib3 pyopenssl deprecation warning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+0.0.53 (2022-10-26)
++++++++++++++++++++
+* Suppress deprecation warning when detecting pyopenssl existence.
+
 0.0.52 (2020-11-25)
 +++++++++++++++++++
 * Changed logging verbosity when closing a stream

--- a/azure/datalake/store/__init__.py
+++ b/azure/datalake/store/__init__.py
@@ -6,7 +6,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-__version__ = "0.0.52"
+__version__ = "0.0.53"
 
 from .core import AzureDLFileSystem
 from .multithread import ADLDownloader


### PR DESCRIPTION
urllib3 is now deprecating pyopenssl and emits a warning whenever the module is accessed. Since this pacakge’s access of the module is already optional, and falls back gracefully when the module does not exist, the warning can simply be suppressed.

See: https://github.com/urllib3/urllib3/issues/2680

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change

### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [ ] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [ ] Links to associated bugs, if any, are in the description.
