### PR TITLE
Remove concat operation from multi-part upload

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 
 Release History
 ===============
-0.0.54 (2025-05-05)
+1.0.1 (2025-05-16)
 +++++++++++++++++++
 * Remove concat operation from multi-part upload. Upload of large fies will now be done in single chunk.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Release History
 ===============
+0.0.54 (2025-05-05)
++++++++++++++++++++
+* Remove concat operation from multi-part upload. Upload of large fies will now be done in single chunk.
 
 1.0.0-alpha0 (2024-07-12)
 +++++++++++++++++++++++++

--- a/azure/datalake/store/transfer.py
+++ b/azure/datalake/store/transfer.py
@@ -285,8 +285,11 @@ class ADLTransferClient(object):
         else:
             tmpdir = None
 
-        # TODO: might need xrange support for py2
-        offsets = range(0, length, self._chunksize)
+        if self._chunksize is None:
+            offsets = [0]  # Treat the entire file as a single chunk
+        else:    
+            # TODO: might need xrange support for py2
+            offsets = range(0, length, self._chunksize)
 
         # in the case of empty files, ensure that the initial offset of 0 is properly added.
         if not offsets:
@@ -304,7 +307,7 @@ class ADLTransferClient(object):
             cstates[(name, offset)] = 'pending'
             self._chunks[(name, offset)] = {
                 "parent": (src, dst),
-                "expected": min(length - offset, self._chunksize),
+                "expected": min(length - offset, self._chunksize or length),
                 "actual": 0,
                 "exception": None}
             logger.debug("Submitted %s, byte offset %d", name, offset)

--- a/tests/test_multithread.py
+++ b/tests/test_multithread.py
@@ -300,7 +300,7 @@ def test_upload_one(local_files, azure):
         # multiple chunks, one thread
         size = 10000
         up = ADLUploader(azure, test_dir / 'bigfile', bigfile, nthreads=1,
-                         chunksize=size//5, client=client, run=False,
+                         client=client, run=False,
                          overwrite=True)
         up.run()
 


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Description of the change
Earlier, upload of large files is done in chunks. Multiple chunks get uploaded to temporary destination file and at last, all the temporary files get merged using concat operation.

With this change, we have removed merge operation and upload of large files will be done in single chunk directly to remote destination file.
### General Guidelines

- [x] The PR has modified HISTORY.rst with an appropriate description of the change and a version increment.
- [x] The PR has supporting test coverage that confirm the expected behavior and protects against regressions, including necessary recordings.
- [ ] Links to associated bugs, if any, are in the description.
